### PR TITLE
Allow unaligned references for Debug implementations

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,6 +77,7 @@
 #![allow(non_upper_case_globals)]
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
+#![warn(unaligned_references)]
 #![cfg_attr(feature = "keep-extern-types", feature(extern_types))]
 
 pub mod libc;


### PR DESCRIPTION
This allows access that is probably UB in order to stay usable with
current nightly compilers. A better solution is needed, but the problem
is not new and this stops the alarms from hindering other work: It makes
riot-sys usable with recent nightlies (the default was switched from
warn to error some time between 2022-03-08 and 2022-04-25).

Creates: https://github.com/RIOT-OS/rust-riot-sys/issues/3