### PR TITLE
Release 0.7.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "riot-sys"
-version = "0.7.7"
+version = "0.7.8"
 authors = ["Christian Amsüss <chrysn@fsfe.org>"]
 edition = "2018"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,8 @@ c2rust-asm-casts = "0.2"
 c2rust-bitfields = { version = "0.3", features = ["no_std"] }
 
 # optionally use RIOT-rs's riot-build
-riot-build = { version = "0.1.0", optional = true }
-riot-rs-core = { version = "0.1.0", optional = true }
+# riot-build = { version = "0.1.0", optional = true }
+# riot-rs-core = { version = "0.1.0", optional = true }
 
 [build-dependencies]
 bindgen = "^0.60.1"
@@ -37,4 +37,4 @@ regex = "1"
 keep-extern-types = []
 
 # this needs to be set to build together with RIOT-rs.
-riot-rs = [ "riot-build", "riot-rs-core", "keep-extern-types" ]
+# riot-rs = [ "riot-build", "riot-rs-core", "keep-extern-types" ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,8 @@ c2rust-asm-casts = "0.2"
 c2rust-bitfields = { version = "0.3", features = ["no_std"] }
 
 # optionally use RIOT-rs's riot-build
-# riot-build = { version = "0.1.0", optional = true }
-# riot-rs-core = { version = "0.1.0", optional = true }
+riot-build = { version = "0.1.0", optional = true }
+riot-rs-core = { version = "0.1.0", optional = true }
 
 [build-dependencies]
 bindgen = "^0.60.1"
@@ -37,4 +37,4 @@ regex = "1"
 keep-extern-types = []
 
 # this needs to be set to build together with RIOT-rs.
-# riot-rs = [ "riot-build", "riot-rs-core", "keep-extern-types" ]
+riot-rs = [ "riot-build", "riot-rs-core", "keep-extern-types" ]


### PR DESCRIPTION
A maintenance release that's primarily made to give riot-wrappers a guarantee about markers that can now be disregarded.