### PR TITLE
build: Add mutex_lock to inline-or-not list

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -543,6 +543,7 @@ fn main() {
         "irq_is_in",
         "irq_restore",
         "mutex_trylock",
+        "mutex_lock",
         "pid_is_valid",
         "shell_run_forever",
         "sock_udp_recv",


### PR DESCRIPTION
https://github.com/RIOT-OS/RIOT/pull/18619 will change a static-ness of a mutex function ... more concretely, it's exposing an already existing flippy-floppiness. This should fix it.

Testing: I haven't tried this out yet, but CI will tell me the same things.