### PR TITLE
Bump version to 0.7.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,8 @@ c2rust-asm-casts = "0.2"
 c2rust-bitfields = { version = "0.3", features = ["no_std"] }
 
 # optionally use RIOT-rs's riot-build
-riot-build = { version = "0.1.0", optional = true }
-riot-rs-core = { version = "0.1.0", optional = true }
+riot-build = { version = "< 0.2.0", optional = true }
+riot-rs-core = { version = "< 0.2.0", optional = true }
 
 [build-dependencies]
 bindgen = "^0.60.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "riot-sys"
-version = "0.7.8"
+version = "0.7.9"
 authors = ["Christian Amsüss <chrysn@fsfe.org>"]
 edition = "2018"
 


### PR DESCRIPTION
Changes:

* `mutex_lock` function is now in the toplevel_from_inline list, making it usable no matter whether it is a static inline function or not
* README extended by note on versioning

---

Procedurally, I plan to wait for this to run through, some riot-rs to be published (even if just as a placeholder), to `cargo publish`, and then merge this fast-forwardly.