### PR TITLE
CI: Update not only riot-* but also its dependencies

### DIFF
--- a/.github/workflows/buildtest.yml
+++ b/.github/workflows/buildtest.yml
@@ -46,7 +46,7 @@ jobs:
         for D in ${DIRS}; do
           cd ${D}
           echo "::group::Building ${D}"
-          cargo update -p riot-sys -p riot-wrappers
+          cargo update -p riot-sys -p riot-wrappers --aggressive
           cargo tree
           make buildtest BUILDTEST_MAKE_REDIRECT=''
           cd ../..


### PR DESCRIPTION
Otherwise, in some cases, the override established in CI will be ignored fully, and the older release would be used instead.

---

This was picked out of https://github.com/RIOT-OS/rust-riot-wrappers/pull/14