### PR TITLE
Drop cty dependency now that core::ffi has that covered

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "riot-sys"
 version = "0.7.16"
 authors = ["Christian Amsüss <chrysn@fsfe.org>"]
-edition = "2018"
+edition = "2021"
 rust-version = "1.64"
 
 description = "Rust FFI wrappers for the RIOT operating system"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "riot-sys"
 version = "0.7.16"
 authors = ["Christian Amsüss <chrysn@fsfe.org>"]
 edition = "2018"
+rust-version = "1.64"
 
 description = "Rust FFI wrappers for the RIOT operating system"
 documentation = "https://rustdoc.etonomy.org/riot_sys/"
@@ -14,7 +15,6 @@ license = "LGPL-2.1"
 links = "riot-sys"
 
 [dependencies]
-cty = "^0.2"
 c2rust-asm-casts = "0.2"
 # Relevant for some boards like the wemos-zero
 c2rust-bitfields = { version = "0.3", features = ["no_std"] }

--- a/build.rs
+++ b/build.rs
@@ -189,7 +189,7 @@ fn main() {
         .header("riot-bindgen.h")
         .clang_args(&cflags)
         .use_core()
-        .ctypes_prefix("libc")
+        .ctypes_prefix("core::ffi")
         // We've traditionally used size_t explicitly and cast it in riot-wrappers; changing this
         // now (going from bindgen 0.60 to 0.64) would break where it's used (although we still
         // might instate a type alias for size_t later instead).

--- a/src/bindgen.rs
+++ b/src/bindgen.rs
@@ -8,6 +8,6 @@
 #![allow(rustdoc::invalid_rust_codeblocks)]
 #![allow(rustdoc::broken_intra_doc_links)]
 
-use crate::libc;
+use core::ffi as libc;
 
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));

--- a/src/inline.rs
+++ b/src/inline.rs
@@ -87,7 +87,7 @@ macro_rules! llvm_asm {
     }};
 }
 
-use cty as libc;
+use core::ffi as libc;
 
 use c2rust_bitfields::*;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,6 +122,7 @@
 #![allow(non_snake_case)]
 #![cfg_attr(feature = "keep-extern-types", feature(extern_types))]
 
+#[deprecated(note = "Use core::ffi types directly")]
 pub mod libc;
 
 mod intrinsics_replacements;

--- a/src/libc.rs
+++ b/src/libc.rs
@@ -5,7 +5,7 @@
 
 #![allow(non_camel_case_types)]
 
-pub use cty::{
+pub use core::ffi::{
     c_char,
     c_double,
     c_float,
@@ -22,5 +22,4 @@ pub use cty::{
     // Not even loading size_t and ssize_t as they don't fit with bindgen's mapping anyway
 };
 
-// Used to be a dedicated type, pub-used to avoid breaking the API
 pub use core::ffi::c_void;


### PR DESCRIPTION
Given that this introduces yet another round of "signed vs unsigned char" errors on ARM architectures, this probably needs to sit and wait for a large breaking change. It's probably worth just biting through that once...