### PR TITLE
Documentation updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Those bindings are inherently unsafe; it is recommended that their safe
 abstractions in the [riot-wrappers] crate are used in most applications.
 
 For a newcomer's starting point, see [RIOT's documentation on using it with Rust].
+This also contains installation instructions / depenendencies.
 
 [riot-wrappers]: https://crates.io/crates/riot-wrappers
 [RIOT's documentation on using it with Rust]: https://doc.riot-os.org/using-rust.html
@@ -51,22 +52,6 @@ Currently, only a subset of all the RIOT headers is processed; all the relevant
 header files are included in this crate's `riot-headers.h` header file. If you
 need access to more RIOT APIs, more includes can be added there.
 
-### External build dependencies
-
-This crate's operation depends on [C2Rust] being installed.
-As of revision 6674d785, the upstream release is suitable for that. Still, installation is a
-bit cumbersome as it requires a particular nightly version:
-
-    $ git clone https://github.com/immunant/c2rust/
-    $ cd c2rust
-    $ rustup install nightly-2019-12-05
-    $ rustup component add --toolchain nightly-2019-12-05 rustfmt rustc-dev
-    $ cargo +nightly-2019-12-05 install --locked --debug --path c2rust
-
-[C2Rust]: https://c2rust.com/
-
-Usually, the `c2rust` binary is selected through the `PATH` environment variable.
-The `C2RUST` environment variable can be used to override this.
 
 ### Versioning
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,38 @@ once the underlying C code is changed, all bets are off.
 Users of `riot-rs` can introspect its markers (see `build.rs`)
 to influence which symbols to use.
 
+#### Markers
+
+Some decisions of downstream crates need to depend on whether some feature is around in
+RIOT. For many things that's best checked on module level, but some minor items have no
+module to mark the feature, and checking for versions by numers is not fine-grained enough,
+so it's easiest to check for concrete strings in the bindgen output.
+
+The `build.rs` of this crate contains a list of marker conditions. These lead to `MARKER_foo=1`
+items emitted that are usable as `DEP_RIOT_SYS_MARKER_foo=1` by crates that explicitly `links =
+"riot-sys"`. They are stable in that they'll only go away in a breaking riot-sys version;
+downstream users likely stop using them earlier because they sooner or later stop supporting
+old RIOT versions.
+
+For example, in [PR #17957](https://github.com/RIOT-OS/RIOT/pull/17957), an argument to a
+particular handler function changed fundamentally; no amount of `.into()` would allow writing
+sensible abstractions. The marker `coap_request_ctx_t` was introduced, and is present
+automatically on all RIOT versions that have that particular pull request merged. Code in
+`riot-wrappers` uses conditions like `#[cfg(marker_coap_request_ctx_t)] ` to decide whether to
+use the old or the new conventions.
+
+These markers are currently checked against bindgen's output, but could query any property
+that riot-sys has access to. The markers are defined in terms of some change having happened
+in RIOT; the way they are tested for can change. (In particular, when riot-sys stops
+supporting an older RIOT version, it can just always emit that marker).
+
+Crates building on this should preferably not alter their own APIs depending on these,
+because that would add extra (and hard-to-track) dimensions to them. If they can, they
+should provide a unified view and degrade gracefully. (For example, riot-wrappers has the
+unit `T` of the `phydat_unit_t` in its enum, but converts it to the generic unspecified unit
+on RIOT versions that don't have the T type yet -- at least for as long as it supports
+2022.01).
+
 ---
 
 The types and constants of RIOT are translated in two forms:

--- a/build.rs
+++ b/build.rs
@@ -589,28 +589,6 @@ fn main() {
         )
         .expect("Failed to write to toplevel_from_inline.rs");
 
-    // Some decisions of downstream crates need to depend on whether some feature is around in
-    // RIOT. For many things that's best checked on module level, but some minor items have no
-    // module to mark the feature, and checking for versions by numers is not fine-grained enough,
-    // so it's easiest to check for concrete strings in the bindgen output.
-    //
-    // These lead to `MARKER_foo=1` items emitted that are usable as `DEP_RIOT_SYS_MARKER_foo=1` by
-    // crates that explicitly `links = "riot-sys"`. They are stable in that they'll only go away in
-    // a breaking riot-sys version; downstream users likely stop using them earlier because they
-    // sooner or later stop supporting old RIOT versions.
-    //
-    // These markers are currently checked against bindgen's output, but could query any property
-    // that riot-sys has access to. The markers are defined in terms of some change having happened
-    // in RIOT; the way they are tested for can change. (In particular, when riot-sys stops
-    // supporting an older RIOT version, it can just always emit that marker).
-    //
-    // Crates building on this should preferably not alter their own APIs depending on these,
-    // because that would add extra (and hard-to-track) dimensions to them. If they can, they
-    // should provide a unified view and degrade gracefully. (For example, riot-wrappers has the
-    // unit `T` of the `phydat_unit_t` in its enum, but converts it to the generic unspecified unit
-    // on RIOT versions that don't have the T type yet -- at least for as long as it supports
-    // 2022.01).
-
     enum MarkerCondition {
         /// This has been around for long enough that no actual check is performed any more, the
         /// marker is just always set. Markers are set to that when the oldest supported RIOT

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@
 //! abstractions in the [riot-wrappers] crate are used in most applications.
 //!
 //! For a newcomer's starting point, see [RIOT's documentation on using it with Rust].
+//! This also contains installation instructions / depenendencies.
 //!
 //! [riot-wrappers]: https://crates.io/crates/riot-wrappers
 //! [RIOT's documentation on using it with Rust]: https://doc.riot-os.org/using-rust.html
@@ -47,22 +48,6 @@
 //! header files are included in this crate's `riot-headers.h` header file. If you
 //! need access to more RIOT APIs, more includes can be added there.
 //!
-//! ## External build dependencies
-//!
-//! This crate's operation depends on [C2Rust] being installed.
-//! As of revision 6674d785, the upstream release is suitable for that. Still, installation is a
-//! bit cumbersome as it requires a particular nightly version:
-//!
-//!     $ git clone https://github.com/immunant/c2rust/
-//!     $ cd c2rust
-//!     $ rustup install nightly-2019-12-05
-//!     $ rustup component add --toolchain nightly-2019-12-05 rustfmt rustc-dev
-//!     $ cargo +nightly-2019-12-05 install --locked --debug --path c2rust
-//!
-//! [C2Rust]: https://c2rust.com/
-//!
-//! Usually, the `c2rust` binary is selected through the `PATH` environment variable.
-//! The `C2RUST` environment variable can be used to override this.
 //!
 //! ## Versioning
 //!


### PR DESCRIPTION
* Remove obsolete C2Rust stuff
* Move what used to be comments (but is becoming really important, giving that RIOT APIs evolve while riot-wrappers goes for stability) into actual docs