### PR TITLE
Add auto_init_utils.h

### DIFF
--- a/riot-headers.h
+++ b/riot-headers.h
@@ -159,6 +159,9 @@
 #include <vfs.h>
 #endif
 #endif
+#ifdef MODULE_AUTO_INIT
+#include "auto_init_utils.h"
+#endif
 
 /* packages */
 #ifdef MODULE_NIMBLE_HOST


### PR DESCRIPTION
This will enable Rust applications to insert themselves into the auto init sequence without the need to go through C files.