### PR TITLE
Add marker for config_auto_init_enable_debug

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -639,6 +639,15 @@ fn main() {
         (Never, "gcoap_resource_t"),
         // See https://github.com/RIOT-OS/RIOT/pull/17957, available TBD
         (NameInCode, "coap_request_ctx_t"),
+        // These are funny because they're not really representative of versions of RIOT, but
+        // really of configuration
+        //
+        // A better long-term solution might be to have riotbuild.h parsed, or to funnel its input
+        // in here through other means.
+        (
+            InCode("pub const CONFIG_AUTO_INIT_ENABLE_DEBUG: u32 = 1;"),
+            "config_auto_init_enable_debug",
+        ),
     ];
     for (needle, name) in markers {
         let found = match needle {


### PR DESCRIPTION
This checks the generated source for a precise line (`pub const CONFIG_AUTO_INIT_ENABLE_DEBUG: u32 = 1;`) and if present, sets the marker.

The `=1` comparison is not too weird because the input to this has been passed through genconfigheader.sh, which ensures that no weird values (eg. `=2`) show up.

The whole line is weird because so far I've used markers to tell whether or not something has become part of the RIOT source, not to check for flags.

It may be practical to do a run through all the items passed through genconfigheader.sh (and thus found in riotbuild.h) for flags which might be enabled but would need checking at build time.

---

So to summarize, I'm not sure yet this is a good approach -- putting it here a) for review and b) to have a branch that can be used by auto-init users (who need some information like this in order to properly initialize their auto_init_module_t strucs).