### PR TITLE
Compile for esp32(s2,c3,..)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,5 +36,12 @@ regex = "1"
 # `extern_types`.
 keep-extern-types = []
 
+# This prevents the `undef` of the dummy atomic definitions in
+# `riot-c2rust.h` in case `stdatomic.h` is somewhere included.
+# Note that these definitions are not realy atomics but placeholders.
+# Thus a programm relying on the atomicity of the transpiled Rust structs
+# will probably not work as intended.
+dummy-atomic-definitions = []
+
 # this needs to be set to build together with RIOT-rs.
 riot-rs = [ "riot-build", "riot-rs-core", "keep-extern-types" ]

--- a/build.rs
+++ b/build.rs
@@ -61,6 +61,14 @@ fn main() {
         let mut consensus_cflag_groups: Option<Vec<Vec<&str>>> = None;
         for entry in parsed.iter() {
             if let Some(consensus_cc) = consensus_cc.as_ref() {
+                // Prevent c++ flags from beeing used.
+                // For example esp32 uses C++ internally.
+                // Since bindings to C++ are not supported by C2Rust
+                // we can savely kick it out anyway.
+                if entry.arguments[0] == "clang++" {
+                    continue;
+                }
+
                 assert!(consensus_cc == &entry.arguments[0])
             } else {
                 consensus_cc = Some(&entry.arguments[0]);

--- a/build.rs
+++ b/build.rs
@@ -463,11 +463,26 @@ fn main() {
     if env::var("CARGO_FEATURE_KEEP_EXTERN_TYPES").is_err() {
         // There's only one `pub type` usually, and that breaks use on stable, and src/inline.rs has a
         // workaround for that
-        rustcode = rustcode.replace("\n    pub type __locale_t;", "");
-        rustcode = rustcode.replace("\n    pub type _IO_wide_data;", "");
-        rustcode = rustcode.replace("\n    pub type _IO_codecvt;", "");
-        rustcode = rustcode.replace("\n    pub type _IO_marker;", "");
-        rustcode = rustcode.replace("\n    pub type __lock;", "");
+        let replacements = [
+            ("\n    pub type __locale_t;", ""),
+            ("\n    pub type _IO_wide_data;", ""),
+            ("\n    pub type _IO_codecvt;", ""),
+            ("\n    pub type _IO_marker;", ""),
+            ("\n    pub type __lock;", ""),
+        ];
+
+        let mut old_len = rustcode.len();
+
+        for (reg, repl) in replacements {
+            rustcode = rustcode.replace(reg, repl);
+
+            if rustcode.len() != old_len {
+                eprintln!("Could not remove {reg} from generated rustcode.\
+This might lead to duplicate definitions. Consider using cargo feature \"keep-extern-types\" if this causes problems")
+            }
+
+            old_len = rustcode.len();
+        }
     }
 
     // Replace the function declarations with ... usually something pub, but special considerations

--- a/build.rs
+++ b/build.rs
@@ -375,8 +375,16 @@ fn main() {
 
     let arguments: Vec<_> = core::iter::once("any-cc".to_string())
         .chain(cflags.into_iter())
+        .chain({
+            if cfg!(feature = "dummy-atomic-definitions") {
+                vec!["-DDUMMY_ATOMICS=1".to_string()]
+            } else {
+                vec![]
+            }
+        })
         .chain(core::iter::once(c2rust_infile.to_string()))
         .collect();
+
     let compile_commands = json!([{
         "arguments": arguments,
         "directory": out_path,

--- a/riot-c2rust.h
+++ b/riot-c2rust.h
@@ -12,10 +12,12 @@
 #define __builtin_arm_get_fpscr __masked_builtin_arm_get_fpscr
 #define __builtin_arm_set_fpscr __masked_builtin_arm_set_fpscr
 extern int missing_implementation_for_fpscr_in_c2rust_see_issue_345;
-static inline int __masked_builtin_arm_get_fpscr(void) {
+static inline int __masked_builtin_arm_get_fpscr(void)
+{
 	return missing_implementation_for_fpscr_in_c2rust_see_issue_345;
 }
-static inline void __masked_builtin_arm_set_fpscr(int fpscr){
+static inline void __masked_builtin_arm_set_fpscr(int fpscr)
+{
 	missing_implementation_for_fpscr_in_c2rust_see_issue_345 = fpscr;
 }
 
@@ -28,8 +30,8 @@ static inline void __masked_builtin_arm_set_fpscr(int fpscr){
 //
 // Proper fix: resolve https://github.com/immunant/c2rust/issues/293
 #define __CLANG_STDATOMIC_H // for clang
-#define _STDATOMIC_H // for GCC
-#define _STDATOMIC_H_ // for newlib
+#define _STDATOMIC_H		// for GCC
+#define _STDATOMIC_H_		// for newlib
 #define ATOMIC_VAR_INIT(x) x
 // FIXME for all: is it really? We don't rely on it, see below on the explicitly included files.
 #define atomic_bool bool
@@ -94,6 +96,9 @@ static inline void __masked_builtin_arm_set_fpscr(int fpscr){
 // Exported Clang AST was invalid. Check warnings above for unimplemented features.
 // --> /usr/lib/gcc/arm-none-eabi/10.3.1/include/stdatomic.h:69:1
 // [-Wclang-ast]
+//
+// undefs can be disabled by using cargo feature: "dummy-atomic-definitions"
+#ifndef DUMMY_ATOMICS
 #undef __CLANG_STDATOMIC_H
 #undef _STDATOMIC_H_
 #undef _STDATOMIC_H
@@ -135,6 +140,7 @@ static inline void __masked_builtin_arm_set_fpscr(int fpscr){
 #undef atomic_ptrdiff_t
 #undef atomic_intmax_t
 #undef atomic_uintmax_t
+#endif
 
 // Allow header files that pull in lots of odd stuff but don't depend on
 // inlines -- like nimble's host/ble_gap.h -- to opt out of C2Rust altogether


### PR DESCRIPTION
When trying to compile RIOT with Rust for esp32(s2,c3) targets i encountered some problems:

(The first two problems are unrelated to this crate but are mentioned since they should show up when testing this.)

* C2Rust compiled with xtensa compatible llvm needed (esp32,s2) 
* C2Rust problematic macro translation https://github.com/immunant/c2rust/issues/803
    causing non compiling code (esp32, s2, c3)
* Some small things here in `rust-riot-sys` need to be considered:
   * Duplicate definitions are created (activate `keep-extern-types` to fix)
   * When using e.g. `netdev_default` C++ files are pulled in and "pollute" `compile-commands.json`
   * The esps use `stdatomic.h` when module `netdev_default` is in 

To circumvent the C2Rust macro problem the fork linked in the issue might be used or for simple test-cases the option `--translate-const-macros` can be removed from `build.rs`.  

For the other 3 things concerning this crate i added ideas how to address them or make them more easily to find,  but they definitely need further discussion:

* Duplicate definition of `__lock` occurs because it is transpiled differently by c2rust and thus doesn't get removed. I only added a warning for this to alert the user that something didn't go as expected
* C++ files: added placeholder just kicking `clang++` out not sure how to address this correctly 
    * The problem here is that C++ files don't have the `std=c11` flag and thus it gets kicked out by the consent strategy
*  The atomic case is explained in `riot-c2rust.h` i thought it might be nice to make this controllable via a feature.
