### PR TITLE
export macro_DAC_LINE

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -274,6 +274,7 @@ fn main() {
         ("ADC_DEV", "adc_t", Some("unsigned num"), false),
         ("TIMER_DEV", "timer_t", Some("unsigned num"), false),
         ("QDEC_DEV", "qdec_t", Some("unsigned num"), false),
+        ("DAC_LINE", "dac_t", Some("unsigned num"), false),
     ];
     let mut macro_functions: Vec<_> = macro_functions
         .iter()


### PR DESCRIPTION
This item was missed because it doesn't follow the XXX_DEV pattern used by other peripherals.

See-Also: https://github.com/RIOT-OS/rust-riot-sys/pull/17
Contributes-To: https://github.com/RIOT-OS/rust-riot-wrappers/pull/36