### PR TITLE
Extern types: Add netq_t, make them large

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -454,6 +454,7 @@ fn main() {
         rustcode = rustcode.replace("\n    pub type _IO_codecvt;", "");
         rustcode = rustcode.replace("\n    pub type _IO_marker;", "");
         rustcode = rustcode.replace("\n    pub type __lock;", "");
+        rustcode = rustcode.replace("\n    pub type netq_t;", "");
     }
 
     // Replace the function declarations with ... usually something pub, but special considerations

--- a/src/inline.rs
+++ b/src/inline.rs
@@ -92,19 +92,22 @@ use cty as libc;
 use c2rust_bitfields::*;
 
 // This is a replacement for the `pub type __locale_t` and the IO lines that C2Rust generates
-// because of something from stdlib; it is stripped out of the compiled code and turned into a void
+// because of something from stdlib; it is stripped out of the compiled code and turned into a u8
 // pointer for lack of better ideas. (Leaving it as a pub struct would require unstable Rust).
+//
+// The type is hugely sized to ensure that things crash (or preferably don't build) if at any point
+// Rust code tries to touch an instance of it, eg. by allocating one on the stack or statically.
 #[cfg(not(feature = "keep-extern-types"))]
-pub type __locale_t = libc::c_void;
+pub type __locale_t = [u8; isize::MAX as _];
 #[cfg(not(feature = "keep-extern-types"))]
-pub type _IO_wide_data = libc::c_void;
+pub type _IO_wide_data = [u8; isize::MAX as _];
 #[cfg(not(feature = "keep-extern-types"))]
-pub type _IO_codecvt = libc::c_void;
+pub type _IO_codecvt = [u8; isize::MAX as _];
 #[cfg(not(feature = "keep-extern-types"))]
-pub type _IO_marker = libc::c_void;
+pub type _IO_marker = [u8; isize::MAX as _];
 #[cfg(not(feature = "keep-extern-types"))]
-pub type __lock = libc::c_void;
+pub type __lock = [u8; isize::MAX as _];
 #[cfg(not(feature = "keep-extern-types"))]
-pub type netq_t = libc::c_void;
+pub type netq_t = [u8; isize::MAX as _];
 
 include!(concat!(env!("OUT_DIR"), "/riot_c2rust_replaced.rs"));

--- a/src/inline.rs
+++ b/src/inline.rs
@@ -104,5 +104,7 @@ pub type _IO_codecvt = libc::c_void;
 pub type _IO_marker = libc::c_void;
 #[cfg(not(feature = "keep-extern-types"))]
 pub type __lock = libc::c_void;
+#[cfg(not(feature = "keep-extern-types"))]
+pub type netq_t = libc::c_void;
 
 include!(concat!(env!("OUT_DIR"), "/riot_c2rust_replaced.rs"));


### PR DESCRIPTION
* Add netq_t which comes in when building with tinydtls
* Protect by making them unreasonably sized

I'll give that a test run on CI; generally, any breakage shown there is something where I'd investigate whether things were already subtly broken previously.