### PR TITLE
Add `random` module to `riot-headers`

### DIFF
--- a/riot-headers.h
+++ b/riot-headers.h
@@ -118,6 +118,9 @@
 #ifdef MODULE_NANOCOAP_SOCK
 #include <net/nanocoap_sock.h>
 #endif
+#ifdef MODULE_RANDOM
+#include <random.h>
+#endif
 #ifdef MODULE_SOCK
 #include <net/sock.h>
 #endif


### PR DESCRIPTION
Needed for https://github.com/RIOT-OS/rust-riot-wrappers/pull/54