### PR TITLE
extern-types: Generate replacement types dynamically

### DIFF
--- a/src/inline.rs
+++ b/src/inline.rs
@@ -98,16 +98,6 @@ use c2rust_bitfields::*;
 // The type is hugely sized to ensure that things crash (or preferably don't build) if at any point
 // Rust code tries to touch an instance of it, eg. by allocating one on the stack or statically.
 #[cfg(not(feature = "keep-extern-types"))]
-pub type __locale_t = [u8; isize::MAX as _];
-#[cfg(not(feature = "keep-extern-types"))]
-pub type _IO_wide_data = [u8; isize::MAX as _];
-#[cfg(not(feature = "keep-extern-types"))]
-pub type _IO_codecvt = [u8; isize::MAX as _];
-#[cfg(not(feature = "keep-extern-types"))]
-pub type _IO_marker = [u8; isize::MAX as _];
-#[cfg(not(feature = "keep-extern-types"))]
-pub type __lock = [u8; isize::MAX as _];
-#[cfg(not(feature = "keep-extern-types"))]
-pub type netq_t = [u8; isize::MAX as _];
+include!(concat!(env!("OUT_DIR"), "/pubtype_replacements.rs"));
 
 include!(concat!(env!("OUT_DIR"), "/riot_c2rust_replaced.rs"));


### PR DESCRIPTION
So far, we maintained a list of extern types that fall out of C2Rust compilation (typically deep in structs we never allocate, so we don't really *need* to know their properties). These types are already defined in such a way that we can't ever allocate them, but would only use them through pointers if at all.

This list was manually maintained and updated whenever something new popped up, typically through some libc.

This PR changes that to recognize extern types from the C2Rust output, and create replacement types on demand. In particular, this should fix an issue when types of the previously encoded names are not extern types on a particular platform, eg `__lock` in #20.

@Remmirad, could you review this? Does your `__lock` issue in #20 go away when applying this (even if you disable the keep-extern-types workaround)?