### PR TITLE
wolfSSL support added

### DIFF
--- a/riot-headers.h
+++ b/riot-headers.h
@@ -184,6 +184,14 @@
 #include "ws281x.h"
 #endif
 
+/* wolfSSL */
+#if defined(MODULE_WOLFSSL) && !defined(IS_C2RUST)
+#include <wolfssl/wolfcrypt/settings.h>
+#include <wolfssl/wolfcrypt/sha256.h>
+#include <wolfssl/ssl.h>
+#include <sock_tls.h>
+#endif
+
 // Note that while the actual definitions are always in board.h, this defines
 // the fallback macros that make sure that in the LED macros' absence,
 // fallbacks are there.


### PR DESCRIPTION
This is the first step to add support for wolfSSL in Rust on RIOT-OS. This has been tested using DTLS 1.3 and using SHA256. There is a work-in-progress wrapper that this sets the base for. 