### PR TITLE
bindgen: Use 0.64

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ riot-build = { version = "< 0.2.0", optional = true }
 riot-rs-core = { version = "< 0.2.0", optional = true }
 
 [build-dependencies]
-bindgen = "^0.60.1"
+bindgen = "^0.64"
 shlex = "^1"
 serde_json = "1"
 serde = { version = "1", features = [ "derive" ] }

--- a/build.rs
+++ b/build.rs
@@ -180,6 +180,10 @@ fn main() {
         .clang_args(&cflags)
         .use_core()
         .ctypes_prefix("libc")
+        // We've traditionally used size_t explicitly and cast it in riot-wrappers; changing this
+        // now (going from bindgen 0.60 to 0.64) would break where it's used (although we still
+        // might instate a type alias for size_t later instead).
+        .size_t_is_usize(false)
         .impl_debug(true)
         // Structs listed here are Packed and thus need impl_debug, but also contain non-Copy
         // members.


### PR DESCRIPTION
This fixes issues when compiling with LLVM 16. New features (in particular the static function wrappers) are yet unused.

Thanks @maribu for reporting and the initial testing.