### PR TITLE
Generate Rust enums from bindgen output

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -235,6 +235,39 @@ fn main() {
         .expect("String writing never fails");
     let bindgen_output = std::str::from_utf8(&bindgen_output).expect("Rust source code is UTF-8");
 
+    // Add enums in here to be translated into Rust enums.
+    // The generated enums will be accessible as `riot_sys::<r_enum_name>`
+    //
+    // To add an enum provide (c_enum_name, new_rust_enum_name)
+    let generate_enums = [("senml_unit_t", "SenmlUnit")];
+
+    let mut enum_output = String::new();
+
+    for (c_enum, r_enum) in generate_enums {
+        let regex = regex::Regex::new(&format!(
+            "pub const {c_enum}_(?P<name>[^:]*):[^=]*= (?P<val>\\d*)"
+        ))
+        .unwrap();
+
+        enum_output.push_str(&format!("pub enum {r_enum} {{\n"));
+
+        for matc in regex.find_iter(bindgen_output) {
+            enum_output.push_str("    ");
+
+            enum_output.push_str(&regex.replace(matc.as_str(), "$name = $val"));
+
+            enum_output.push_str(",\n");
+        }
+
+        enum_output.push_str("}\n\n");
+    }
+
+    let enums_outfilename = out_path.join("enums.rs");
+    std::fs::File::create(enums_outfilename)
+        .expect("Could not create enums.rs file")
+        .write_all(enum_output.as_bytes())
+        .expect("Could not write enums to enums.rs");
+
     // Build a compile_commands.json, and run C2Rust
     //
     // The output is cleared beforehand (for c2rust no-ops when an output file is present), and the

--- a/src/bindgen.rs
+++ b/src/bindgen.rs
@@ -11,3 +11,5 @@
 use crate::libc;
 
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
+
+include!(concat!(env!("OUT_DIR"), "/enums.rs"));


### PR DESCRIPTION
C enums handled by bindgen are translated into something like this: `pub const c_enum_name_enum_variant`. This is a bit annoying when someone wants to use them as a correct Rust enum, because one has to basically rewrite and maintain a separate Rust enum. The idea here is now to provide a list inside of `build.rs` just like with the macros where enums can be registered to be translated into Rust. `build.rs` will scan the bindgenoutput for the c enums and create the corresponding Rust enums in `enums.rs`

This would have the side effect, that the enum list would automatically updated with RIOT. I am not 100% sure this is desirable but if one would mark the enums as `non_exhaustive` "older" Rust code should still work with new RIOT versions. My hope is that this could make things a bit easier to maintain and build.