### PR TITLE
macros: Rename ADC_DEV to ADC_LINE

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -275,7 +275,7 @@ fn main() {
         // pattern.
         ("UART_DEV", "uart_t", Some("unsigned num"), false),
         ("PWM_DEV", "pwm_t", Some("unsigned num"), false),
-        ("ADC_DEV", "adc_t", Some("unsigned num"), false),
+        ("ADC_LINE", "adc_t", Some("unsigned num"), false),
         ("TIMER_DEV", "timer_t", Some("unsigned num"), false),
         ("QDEC_DEV", "qdec_t", Some("unsigned num"), false),
         ("DAC_LINE", "dac_t", Some("unsigned num"), false),


### PR DESCRIPTION
ADC_DEV does not exist in RIOT (and thus, no corresponding code was generated for this ever); the macro that goes into adc_init's argument is ADC_LINE.

Follow-up-for: https://github.com/RIOT-OS/rust-riot-sys/pull/17