### PR TITLE
build: Fix randomly missing -I entries

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -102,6 +102,15 @@ fn main() {
                             keep
                         })
                         .collect();
+                    // Hot-fixing the merging algorithm to even work when an (always to be kept) -I
+                    // is not in the initial set
+                    for group in cflag_groups.drain(..) {
+                        if group[0].starts_with("-I") {
+                            if !consensus_cflag_groups.contains(&group) {
+                                consensus_cflag_groups.push(group);
+                            }
+                        }
+                    }
                 }
             } else {
                 consensus_cflag_groups = Some(cflag_groups);


### PR DESCRIPTION
The algorithm for building the consensus CFLAGS was flawed in that the special-casing of `-I path` options only succeeded if the given option was in the first entry of the compile commands list.

While the algorithm can certainly need an overhaul, this is the minimally intrusive fix.