### PR TITLE
Bump version to 0.7.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "riot-sys"
-version = "0.7.9"
+version = "0.7.10"
 authors = ["Christian Amsüss <chrysn@fsfe.org>"]
 edition = "2018"
 


### PR DESCRIPTION
Marking the version currently being pulled into RIOT in https://github.com/RIOT-OS/RIOT/pull/20303

Changes:

* Add macro support for ADC_LINE, DAC_LINE, I2C_DEV, PWM_DEV, QDEC_DEV, SPI_DEV, TIMER_DEV, UART_DEV.
* Added includes:
  * auto_init_utils.h
  * random.h
  * riotboot/slot.h
  * suit.h / suit/*
  * uuid.h
  * wolfssl/*
* Dynamically generate extern-types.
* Deprecate markers in favor of an exported BINDGEN_OUTPUT_FILE.
* Documentation updates.
* Update bindgen.
* Fix processing of compile-commands.json.