### PR TITLE
Small build system updates, make RIOT_USEMODULE optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ riot-rs-core = { version = "< 0.2.0", optional = true }
 
 [build-dependencies]
 bindgen = "^0.64"
-shlex = "^1"
+shlex = "^1.3"
 serde_json = "1"
 serde = { version = "1", features = [ "derive" ] }
 regex = "1"

--- a/README.md
+++ b/README.md
@@ -60,10 +60,16 @@ and efforts are made to not make breaking changes even while in the 0.x phase.
 Note that as it passes on RIOT internals,
 any of the SemVer guarantees only hold when built on the *same* RIOT --
 once the underlying C code is changed, all bets are off.
-Users of `riot-rs` can introspect its markers (see `build.rs`)
-to influence which symbols to use.
+Users of `riot-rs` can introspect the `DEP_RIOT_SYS_...` variables
+that are available to crates that set `links = "riot-sys"`
+to affect the symbols those crates use.
+Typical variables to inspect are `DEP_RIOT_SYS_BINDGEN_OUTPUT_FILE`
+(to determine whether a symbol is imported in the first place, eg. when RIOT renames something)
+and `DEP_RIOT_SYS_CFLAGS` which includes the enabled modules.
 
 #### Markers
+
+**Deprecated, see below**.
 
 Some decisions of downstream crates need to depend on whether some feature is around in
 RIOT. For many things that's best checked on module level, but some minor items have no

--- a/build.rs
+++ b/build.rs
@@ -126,10 +126,10 @@ fn main() {
             #[cfg(not(feature = "riot-rs"))]
             {
                 println!("cargo:rerun-if-env-changed=RIOT_USEMODULE");
-                env::var("RIOT_USEMODULE").expect(&format!(
-                    "RIOT_USEMODULE is required when {} is given",
-                    &compile_commands_json,
-                ))
+                // We tolerate the absence. Older versions of riot-wrappers would then fail to
+                // enable modules, but newer versions just work without it (and would need a dummy
+                // variable passed in otherwise). On the long run, this is going away anyway.
+                env::var("RIOT_USEMODULE").unwrap_or_default()
             }
             #[cfg(feature = "riot-rs")]
             {

--- a/build.rs
+++ b/build.rs
@@ -119,7 +119,8 @@ fn main() {
         cc = consensus_cc
             .expect("Entries are present in compile_commands.json")
             .to_string();
-        cflags = shlex::join(consensus_cflag_groups.unwrap().iter().flatten().map(|s| *s));
+        cflags = shlex::try_join(consensus_cflag_groups.unwrap().iter().flatten().map(|s| *s))
+            .expect("Input is not expected to contain NUL characters");
 
         let usemodule = {
             #[cfg(not(feature = "riot-rs"))]

--- a/build.rs
+++ b/build.rs
@@ -642,8 +642,6 @@ fn main() {
         /// This is equivalent to not having the marker in the first place, except that their
         /// presence serves as a reminder to not reuse that marker name.
         Never,
-        /// A marker that is set if the given string is found in the bindgen output.
-        InCode(&'static str),
         /// A marker that is set if its name is found in the bindgen output. Shorthand for
         /// Text(name).
         NameInCode,
@@ -673,7 +671,6 @@ fn main() {
     ];
     for (needle, name) in markers {
         let found = match needle {
-            InCode(s) => bindgen_output.contains(s),
             NameInCode => bindgen_output.contains(name),
             Always => true,
             Never => false,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,10 +56,16 @@
 //! Note that as it passes on RIOT internals,
 //! any of the SemVer guarantees only hold when built on the *same* RIOT --
 //! once the underlying C code is changed, all bets are off.
-//! Users of `riot-rs` can introspect its markers (see `build.rs`)
-//! to influence which symbols to use.
+//! Users of `riot-rs` can introspect the `DEP_RIOT_SYS_...` variables
+//! that are available to crates that set `links = "riot-sys"`
+//! to affect the symbols those crates use.
+//! Typical variables to inspect are `DEP_RIOT_SYS_BINDGEN_OUTPUT_FILE`
+//! (to determine whether a symbol is imported in the first place, eg. when RIOT renames something)
+//! and `DEP_RIOT_SYS_CFLAGS` which includes the enabled modules.
 //!
 //! ### Markers
+//!
+//! **Deprecated, see below**.
 //!
 //! Some decisions of downstream crates need to depend on whether some feature is around in
 //! RIOT. For many things that's best checked on module level, but some minor items have no


### PR DESCRIPTION
These are the non-breaking parts of #38.