### PR TITLE
Add workaround for VaList being generated in v(f)printf

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -486,6 +486,13 @@ fn main() {
             .to_string();
     }
 
+    // On 64-bit native, what gets emitted as vprintf(_, _, _: __builtin_va_list) gets emitted as
+    // vprintf(_, _, _: core::ffi::VaList), which is unsupported in stable -- but we don't use that
+    // function, it's just an unfortunate side effect of --preserve-unused-functions. This quick
+    // workaround enables building and ensures that the function is never called.
+    rustcode = rustcode.replace("::core::ffi::VaList", "::core::convert::Infallible");
+    rustcode = rustcode.replace("__arg.as_va_list()", "__arg");
+
     // Replace the function declarations with ... usually something pub, but special considerations
     // may apply
     let mut rustcode_functionsreplaced = String::new();


### PR DESCRIPTION
It's not pretty, but I do plan to reduce the amount of c2rust code anyway, and then this would go away again. (Because vprintf should really not be one of our exported functions).

This is the only error left on Rust for 64bit hosts after https://github.com/RIOT-OS/RIOT/pull/20315