### PR TITLE
Release v0.7.11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "riot-sys"
-version = "0.7.10"
+version = "0.7.11"
 authors = ["Christian Amsüss <chrysn@fsfe.org>"]
 edition = "2018"
 


### PR DESCRIPTION
The current HEAD has been used in RIOT for some time.