### PR TITLE
headers: Add hashes

### DIFF
--- a/.github/workflows/formal.yml
+++ b/.github/workflows/formal.yml
@@ -8,17 +8,19 @@ on:
 jobs:
   rustfmt:
     runs-on: ubuntu-latest
-    container: rustlang/rust:nightly
+    container: docker.io/rust
     steps:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
+    - name: Add rustfmt component
+      run: rustup component add rustfmt
     - name: Run cargo-fmt
       run: cargo fmt --check
 
   cargo-readme:
     runs-on: ubuntu-latest
-    container: rustlang/rust:nightly
+    container: docker.io/rust
     steps:
     - uses: actions/checkout@v3
       with:
@@ -28,4 +30,4 @@ jobs:
         crate: cargo-readme
         version: latest
     - name: Verify that README.rst is up to date
-      run: cargo +nightly readme | diff /dev/stdin README.md
+      run: cargo readme | diff /dev/stdin README.md

--- a/riot-headers.h
+++ b/riot-headers.h
@@ -112,6 +112,17 @@
 #ifdef MODULE_GNRC_ICMPV6
 #include "net/gnrc/icmpv6.h"
 #endif
+#ifdef MODULE_HASHES
+#include <hashes.h>
+#include <hashes/aes128_cmac.h>
+#include <hashes/md5.h>
+#include <hashes/pbkdf2.h>
+#include <hashes/sha1.h>
+#include <hashes/sha224.h>
+#include <hashes/sha256.h>
+#include <hashes/sha3.h>
+#include <hashes/sha512.h>
+#endif
 #ifdef MODULE_NANOCOAP
 #include <net/nanocoap.h>
 #endif


### PR DESCRIPTION
These were already conditionally included, but it is unclear which transitive dependency triggered that.

This increases the required RIOT version to something around 2024.01, because https://github.com/RIOT-OS/RIOT/pull/19969 added sha512 support – that's well within the riot-sys stability guarantees.