### PR TITLE
Release 0.7.12

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "riot-sys"
-version = "0.7.11"
+version = "0.7.12"
 authors = ["Christian Amsüss <chrysn@fsfe.org>"]
 edition = "2018"
 


### PR DESCRIPTION
Changes:

* Add headers for hash functions

Waiting for https://github.com/RIOT-OS/RIOT/pull/20489 where those receive the extra testing of the full RIOT CI