### PR TITLE
Bump version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "riot-sys"
-version = "0.7.12"
+version = "0.7.13"
 authors = ["Christian Amsüss <chrysn@fsfe.org>"]
 edition = "2018"
 


### PR DESCRIPTION
Changes:

* Expose LED[0-7]_IS_PRESENT macro with absent value -1

This has not undergone a full scale RIOT test, but is small enough I think there won't be any trouble.