### PR TITLE
dep: Update bindgen to 0.69

### DIFF
--- a/.github/workflows/buildtest.yml
+++ b/.github/workflows/buildtest.yml
@@ -37,7 +37,7 @@ jobs:
       # update` is much faster the second time (so a parallel execution may
       # still be faster but uses 3x the resources)
       run: |
-        export BOARDS='native sltb001a samr21-xpro'
+        BOARDS='native sltb001a samr21-xpro'
         DIRS='examples/lang_support/official/rust-hello-world examples/lang_support/official/rust-gcoap tests/rust_minimal'
         # It appears that there has to be output before :: commands really catch on
         echo "Building ${DIRS} on ${BOARDS}"
@@ -45,10 +45,10 @@ jobs:
         cd RIOT
         for D in ${DIRS}; do
           cd ${D}
-          echo "::group::Building ${D}"
+          echo "::group::Preparing ${D}"
           cargo update -p riot-sys -p riot-wrappers --aggressive
           cargo tree
-          make buildtest BUILDTEST_MAKE_REDIRECT=''
           cd -
           echo "::endgroup::"
         done
+        ./dist/tools/compile_test/compile_like_murdock.py --boards $BOARDS --apps $DIRS -j16

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ riot-build = { version = "< 0.2.0", optional = true }
 riot-rs-core = { version = "< 0.2.0", optional = true }
 
 [build-dependencies]
-bindgen = "^0.64"
+bindgen = "^0.69.4" # starting 0.70, there is something that goes wrong around calculating native's max_align_t
 shlex = "^1.3"
 serde_json = "1"
 serde = { version = "1", features = [ "derive" ] }

--- a/build.rs
+++ b/build.rs
@@ -241,7 +241,7 @@ fn main() {
         .no_debug("ble_hci_le_setup_iso_data_path_cp")
         .no_debug("ext_adv_report")
         .derive_default(true)
-        .parse_callbacks(Box::new(bindgen::CargoCallbacks))
+        .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
         .generate()
         .expect("Unable to generate bindings");
 


### PR DESCRIPTION
This is a regular "let's not leave old dependencies around" update with no real changes.

Going to 0.70 would be great, but so far introduces breakage around the size of max_align_t (might be related to the new --override-abi switch).