### PR TITLE
headers: Add tiny_strerror

### DIFF
--- a/riot-headers.h
+++ b/riot-headers.h
@@ -164,6 +164,9 @@
 #ifdef MODULE_RIOTBOOT_SLOT
 #include "riotboot/slot.h"
 #endif
+#ifdef MODULE_TINY_STRERROR
+#include "tiny_strerror.h"
+#endif
 #ifdef MODULE_UUID
 #include "uuid.h"
 #endif


### PR DESCRIPTION
This helps https://github.com/RIOT-OS/rust-riot-wrappers/pull/128 also implement core::error::Error