### PR TITLE
headers: Don't let C2Rust process xtimer

### DIFF
--- a/riot-headers.h
+++ b/riot-headers.h
@@ -171,7 +171,10 @@
 #include "uuid.h"
 #endif
 #ifdef MODULE_XTIMER
+// Uses C11 generics since https://github.com/RIOT-OS/RIOT/pull/20494
+#ifndef IS_C2RUST
 #include <xtimer.h>
+#endif
 #endif
 #ifdef MODULE_ZTIMER
 #include <ztimer.h>


### PR DESCRIPTION
xtimer, in a static function, uses `_div_round_up` which is implemented using C11 generics.

As a general rule we should make c2rust more opt-in than opt-out (providing concrete known translatable functions rather than a catch-all conversion), but for now, this should solve the issue.