### PR TITLE
headers: Add ztimer64

### DIFF
--- a/riot-headers.h
+++ b/riot-headers.h
@@ -176,6 +176,11 @@
 #ifdef MODULE_ZTIMER
 #include <ztimer.h>
 #endif
+#ifdef MODULE_ZTIMER64
+#ifndef IS_C2RUST
+#include <ztimer64.h>
+#endif
+#endif
 #ifdef MODULE_ZTIMER_PERIODIC
 #include <ztimer/periodic.h>
 #endif


### PR DESCRIPTION
Not including it for C2Rust just to keep small the API surface that we'll ditch when making C2Rust opt-in by header.