### PR TITLE
Bump version to 0.7.15

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "riot-sys"
-version = "0.7.14"
+version = "0.7.15"
 authors = ["Christian Amsüss <chrysn@fsfe.org>"]
 edition = "2018"
 


### PR DESCRIPTION
RIOT is in hard freeze and this version is planned for 2025.01 -- and should thus also be on crates.io for easy use in out-of-tree applications.

---

Changes:

* Add headers: nimble_autoadv, ztimer64.
* Add more items to the debug implementation exclude ist.
* Hide xtimer from C2Rust.

  This is technically breaking, but there were no components that gave anyone reason to use it.