### PR TITLE
Release version 0.7.16

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "riot-sys"
-version = "0.7.15"
+version = "0.7.16"
 authors = ["Christian Amsüss <chrysn@fsfe.org>"]
 edition = "2018"
 


### PR DESCRIPTION
Changes:

* Interaction with other crates:
  - Update bindgen 0.72.
  - Allow c2rust > 0.20.
* Make WS281x functions available across a wider range of RIOT versions.
* Silence false positive warnings.
* CI updates.

---

Releasing with the WS281x change makes it easier to annotate in riot-wrappers what that this new version is needed now.