### PR TITLE
Drop c2rust-* dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,6 @@ links = "riot-sys"
 
 [dependencies]
 c2rust-asm-casts = "0.2"
-# Relevant for some boards like the wemos-zero
-c2rust-bitfields = { version = "0.3", features = ["no_std"] }
 
 # optionally use RIOT-rs's riot-build
 riot-build = { version = "< 0.2.0", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,6 @@ license = "LGPL-2.1"
 links = "riot-sys"
 
 [dependencies]
-c2rust-asm-casts = "0.2"
-
 # optionally use RIOT-rs's riot-build
 riot-build = { version = "< 0.2.0", optional = true }
 riot-rs-core = { version = "< 0.2.0", optional = true }

--- a/src/inline.rs
+++ b/src/inline.rs
@@ -89,8 +89,6 @@ macro_rules! llvm_asm {
 
 use core::ffi as libc;
 
-use c2rust_bitfields::*;
-
 // This is a replacement for the `pub type __locale_t` and the IO lines that C2Rust generates
 // because of something from stdlib; it is stripped out of the compiled code and turned into a u8
 // pointer for lack of better ideas. (Leaving it as a pub struct would require unstable Rust).


### PR DESCRIPTION
This is currently a source of compilation failures on native, and modules that pull in anything bitfieldish should just not go through c2rust in the first place.

In a sense, this would be a light form of #55 (as it probably results in disabling modules for c2rust, but only those that had breakage on some platforms anyway).