### PR TITLE
Opt into c2rust per item

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,12 @@ riot-build = { version = "< 0.2.0", optional = true }
 riot-rs-core = { version = "< 0.2.0", optional = true }
 
 [build-dependencies]
-bindgen = "^0.72.0"
+# Generally that is 0.72.1 plus some recent changes -- but the one thing that
+# matters over 0.72.1 is that it merges
+# <https://github.com/rust-lang/rust-bindgen/pull/2403> to fix
+# <https://github.com/rust-lang/rust-bindgen/issues/2991>, which affects only
+# native32.
+bindgen = { git = "https://github.com/chrysn-pull-requests/rust-bindgen", branch = "extended-floats"}
 shlex = "^1.3"
 serde_json = "1"
 serde = { version = "1", features = [ "derive" ] }

--- a/build.rs
+++ b/build.rs
@@ -630,6 +630,16 @@ fn main() {
 
     rustcode = rustcode_functionsreplaced;
 
+    // We don't even need that function any more, we just have that in there so that c2rust gives
+    // us its callees as functions. (In bindgen, we'd just list the functions we'd like to have).
+    rustcode = rustcode.replace(
+        "pub pub unsafe fn use_everything()",
+        "#[cfg(false)] unsafe fn use_everything()",
+    );
+    // The macro_ wrappers are already `pub` because they are regular functions we create here that
+    // just go around the macro code; removing the double pub.
+    rustcode = rustcode.replace("pub pub unsafe fn ", "pub unsafe fn ");
+
     let output_replaced = out_path.join("riot_c2rust_replaced.rs");
     std::fs::File::create(output_replaced)
         .expect("Failed to create riot_c2rust_replaced.rs")

--- a/build.rs
+++ b/build.rs
@@ -491,7 +491,6 @@ fn main() {
         .args(&[
             "transpile",
             compile_commands_name,
-            "--preserve-unused-functions",
             "--emit-modules",
             "--emit-no-std",
             translate_const_macros_arg,

--- a/riot-c2rust.h
+++ b/riot-c2rust.h
@@ -148,3 +148,56 @@ static inline void __masked_builtin_arm_set_fpscr(int fpscr){
 #define IS_C2RUST
 
 #include "riot-headers.h"
+
+void use_everything(void) {
+	/* While most of them are from modules somewhere, we only need to make them
+	 * conditional if their corresponding includes in riot-headers.h are
+	 * conditional. */
+
+	ztimer_acquire(0);
+	thread_get(0);
+	thread_getpid();
+	pid_is_valid(0);
+	gpio_is_valid(0);
+	irq_is_in();
+	irq_is_enabled();
+	irq_disable();
+	irq_restore(0);
+	mutex_lock(0);
+	mutex_trylock(0);
+	ztimer_now(0);
+	ztimer_spin(0, 0);
+
+	gnrc_netapi_dispatch_send(0, 0, 0);
+	gnrc_netif_hdr_sizeof(0);
+	gnrc_pktbuf_release(0);
+	gnrc_pkt_len(0);
+	gnrc_pkt_count(0);
+
+	thread_measure_stack_free(0);
+
+	gnrc_ipv6_nib_nc_get_ar_state(0);
+	gnrc_netif_ipv6_addrs_get(0, 0, 0);
+	ipv6_addr_is_unspecified(0);
+	ipv6_addr_is_loopback(0);
+	ipv6_addr_is_multicast(0);
+	ipv6_addr_is_link_local(0);
+	gnrc_ipv6_nib_nc_get_iface(0);
+	gnrc_netif_ipv6_addrs_get(0, 0, 0);
+	gnrc_ipv6_nib_nc_get_nud_state(0);
+	gnrc_ipv6_nib_nc_is_router(0);
+
+#ifdef MODULE_NANOCOAP
+	coap_pkt_set_code(0, 0);
+	coap_get_code_raw(0);
+#endif
+
+#ifdef MODULE_SOCK_UDP
+	sock_udp_send(0, 0, 0, 0);
+	sock_udp_recv(0, 0, 0, 0, 0);
+#endif
+
+#ifdef MODULE_SOCK
+	gnrc_netreg_entry_init_cb(0, 0, 0);
+#endif
+}

--- a/riot-c2rust.h
+++ b/riot-c2rust.h
@@ -200,4 +200,8 @@ void use_everything(void) {
 #ifdef MODULE_SOCK
 	gnrc_netreg_entry_init_cb(0, 0, 0);
 #endif
+
+#ifdef MODULE_SHELL
+	shell_run_forever(0, 0, 0);
+#endif
 }


### PR DESCRIPTION
#55 and its sibling #65 are limited by even IWYU pulling in lots of idioms.

Maybe we can get rid of what was probably a mistake in 2020: including everything (which was done because the items we need are all static functions or macros, and there's no "public" declaration).