### PR TITLE
Start 0.8 release cycle

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "riot-sys"
-version = "0.7.16"
+version = "0.8.0"
 authors = ["Christian Amsüss <chrysn@fsfe.org>"]
 edition = "2018"
 


### PR DESCRIPTION
After this commit, breaking changes will be merged until 0.8.0 is declared.

---

After this, we can start merging all the "wait for breaking" changes.

riot-wrappers can start using "0.7 or 0.8", because the promise of this series is not to do anything that breaks the wrappers.

Some copy-paste from what I said on the RIOT channel on this:

> PSA for riot-sys users: With https://github.com/RIOT-OS/RIOT/pull/22229 passing, which tests two PRs from riot-sys that are breaking there, I'll start a cycle of riot-sys having technically breaking changes.
> This will be accompanied by its version number going up. Users through riot-wrappers should not be affected, as the breakage only affects items not used through there (any more).
> Many uses of riot-sys go through git; those will not fail but get a warning: The last 0.7 release is 0.7.16, which is what is currently the git main. The next commits onto main will go to 0.8.0-alpha.0 until there is a crates.io release, so RIOT builds (esp. before the next bumps) will show warnings that the git patch does not apply as it's 0.8 and thus incompatible, but that doesn't harm as what used to be there on git is now also published on crates.io, and that is what cargo falls back to.