### PR TITLE
bindgen: Document why we use the size_t != usize behavior

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -190,9 +190,9 @@ fn main() {
         .clang_args(&cflags)
         .use_core()
         .ctypes_prefix("core::ffi")
-        // We've traditionally used size_t explicitly and cast it in riot-wrappers; changing this
-        // now (going from bindgen 0.60 to 0.64) would break where it's used (although we still
-        // might instate a type alias for size_t later instead).
+        // This is the defensive choice in presence of odd targets, as it forces us to be explicit
+        // more often: Bindgen would err with "Target platform requires `--no-size_t-is-usize`." in
+        // some cases, even though we have not encountered them yet.
         .size_t_is_usize(false)
         .impl_debug(true)
         // Structs listed here are Packed and thus need impl_debug, but also contain non-Copy


### PR DESCRIPTION
Follow-up to https://github.com/RIOT-OS/rust-riot-sys/pull/14 -- this is mostly to acknowledge that indeed the topic *was* considered after being left as a TBD there.

As this is really just a comment change, merging this without further tests or review.