### PR TITLE
c2rust: Export gnrc_netreg_entry_init_pid

### DIFF
--- a/riot-c2rust.h
+++ b/riot-c2rust.h
@@ -186,6 +186,7 @@ void use_everything(void) {
 	gnrc_netif_ipv6_addrs_get(0, 0, 0);
 	gnrc_ipv6_nib_nc_get_nud_state(0);
 	gnrc_ipv6_nib_nc_is_router(0);
+	gnrc_netreg_entry_init_pid(0, 0, 0);
 
 #ifdef MODULE_NANOCOAP
 	coap_pkt_set_code(0, 0);


### PR DESCRIPTION
The function is actually used in riot-wrappers, so not listing it initially was a regression in [66] that went unchecked because none of the standard tests ran GNRC stuff.

[66]: https://github.com/RIOT-OS/rust-riot-sys/pull/66

---

Making the out-of-tree examples ship-shape and thus CI-integratable should help avoid this in the future. (An alternative would be to add better test coverage on GNRC).