### PR TITLE
headers: Sharpen criterion for presence of gnrc_netreg_entry_init_cb

### DIFF
--- a/riot-c2rust.h
+++ b/riot-c2rust.h
@@ -198,7 +198,7 @@ void use_everything(void) {
 	sock_udp_recv(0, 0, 0, 0, 0);
 #endif
 
-#ifdef MODULE_SOCK
+#ifdef MODULE_GNRC_NETAPI_CALLBACKS
 	gnrc_netreg_entry_init_cb(0, 0, 0);
 #endif
 


### PR DESCRIPTION
Should have checked at the definition site, now using the module criterion from the original code.

Trivial enough to self-merge.